### PR TITLE
Improve the robustness of the contour file search routine

### DIFF
--- a/rts_to_npy.py
+++ b/rts_to_npy.py
@@ -18,7 +18,7 @@ def load(path, max_number_of_coords=50000, parallel=False, downscaling=0):
     def modality_check(x):
         try:
             dcm = pydicom.read_file(x)
-            if dcm.Modality.lower() == "rtstruct":
+            if "Modality" in dcm.dir() and dcm.Modality.lower() == "rtstruct":
                 return True
             else:
                 return False

--- a/rts_to_npy.py
+++ b/rts_to_npy.py
@@ -25,7 +25,7 @@ def load(path, max_number_of_coords=50000, parallel=False, downscaling=0):
         except pydicom.errors.InvalidDicomError:
             return False
 
-    files = [x for x in glob.glob(os.path.join(path, '*')) if os.path.isfile(x)]
+    files = [x for x in glob.glob(os.path.join(path, '**/*'), recursive=True) if os.path.isfile(x)]
     logging.info('Found %s Files in path' % len(files))
     rtstruct = [x for x in files if modality_check(x)]
 


### PR DESCRIPTION
I noticed that some DICOM datasets do not have a flat directory structure, but instead place the CT slices and/or contour (RTSTRUCT) files in subdirectories. This is fixed by using glob.glob's recursive argument.

In addition, our treatment planning system also generates a "DICOMDIR" file. This file can actually be read with pydicom.read_file(), but it does not have a "Modality" tag. I added a check before accessing dcm.Modality.

